### PR TITLE
Add fine-tuning torch datasets

### DIFF
--- a/replibert/replibert/data/finetuning/datasets.py
+++ b/replibert/replibert/data/finetuning/datasets.py
@@ -1,0 +1,67 @@
+from typing import Callable, Tuple, Optional, Any
+
+import torch
+from datasets import load_from_disk
+
+
+class FineTuningDataset(torch.utils.data.Dataset):
+    def __init__(self, dataset_dir: str = None, split: str = 'train', n_samples: Optional[int] = None,
+                 transformation: Optional[Callable] = None, hf_dataset=None):
+        if hf_dataset is not None:
+            self.hf_dataset = hf_dataset
+        else:
+            self.hf_dataset = load_from_disk(dataset_dir)[split]
+            if n_samples is not None:
+                self.hf_dataset = self.hf_dataset.select(range(min(n_samples, len(self.hf_dataset))))
+        self.transformation = transformation
+
+    def __len__(self) -> int:
+        return len(self.hf_dataset)
+
+    def __getitem__(self, idx: int) -> Tuple[Any, Any]:
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+class CivilCommentsDataset(FineTuningDataset):
+    def __getitem__(self, idx: int) -> Tuple[Any, Any]:
+        item = self.hf_dataset[idx]
+        xi = item["text"]
+        yi = {
+            "identity_attack": torch.tensor(item["identity_attack"], dtype=torch.float),
+            "insult": torch.tensor(item["insult"], dtype=torch.float),
+            "obscene": torch.tensor(item["obscene"], dtype=torch.float),
+            "severe_toxicity": torch.tensor(item["severe_toxicity"], dtype=torch.float),
+            "sexual_explicit": torch.tensor(item["sexual_explicit"], dtype=torch.float),
+            "threat": torch.tensor(item["threat"], dtype=torch.float),
+            "toxicity": torch.tensor(item["toxicity"], dtype=torch.float)
+        }
+        if self.transformation:
+            xi = self.transformation(xi)
+        return xi, yi
+
+
+class JigsawToxicityDataset(FineTuningDataset):
+    def __getitem__(self, idx: int) -> Tuple[Any, Any]:
+        item = self.hf_dataset[idx]
+        xi = item["comment_text"]
+        yi = {
+            "toxic": torch.tensor(item["toxicity"], dtype=torch.float),
+            "severe_toxic": torch.tensor(item["severe_toxicity"], dtype=torch.float),
+            "obscene": torch.tensor(item["obscene"], dtype=torch.float),
+            "threat": torch.tensor(item["threat"], dtype=torch.float),
+            "insult": torch.tensor(item["insult"], dtype=torch.float),
+            "identity_hate": torch.tensor(item["identity_attack"], dtype=torch.float)
+        }
+        if self.transformation:
+            xi = self.transformation(xi)
+        return xi, yi
+
+
+class SST2Dataset(FineTuningDataset):
+    def __getitem__(self, idx: int) -> Tuple[Any, Any]:
+        item = self.hf_dataset[idx]
+        xi = item["sentence"]
+        yi = torch.tensor(item["label"], dtype=torch.long)
+        if self.transformation:
+            xi = self.transformation(xi)
+        return xi, yi

--- a/replibert/replibert/data/training/dataset.py
+++ b/replibert/replibert/data/training/dataset.py
@@ -20,17 +20,3 @@ class TrainingDataset(Dataset):
             'special_tokens_mask': self.special_tokens_masks[idx],
             'mlm_labels': self.mlm_labels[idx]
         }
-
-
-def load_data(path: str) -> Dataset:
-    """
-    Load a dataset from a file.
-
-    Args:
-        path (str): The path to the file containing the dataset.
-
-    Returns:
-        Dataset: The loaded dataset.
-    """
-    hf_dataset = hf_ds.load_from_disk(path)
-    return TrainingDataset(hf_dataset)

--- a/replibert/replibert/data/utils.py
+++ b/replibert/replibert/data/utils.py
@@ -1,0 +1,116 @@
+from typing import Callable, Tuple, Optional, Any, Generator, Type
+
+import torch
+
+from data.finetuning.datasets import CivilCommentsDataset, JigsawToxicityDataset, SST2Dataset
+
+
+def load_data(
+        dataset: str,
+        dataset_dir: str,
+        transformation: Optional[Callable[[Any], Any]] = None,
+        n_train: Optional[int] = None,
+        n_test: Optional[int] = None
+) -> Tuple[Generator[Tuple[Any, Any], None, None], Generator[Tuple[Any, Any], None, None]]:
+    """
+    Load data and return generators for training and test sets.
+
+    Args:
+        dataset (str): The name of the dataset to load ('civil_comments', 'jigsaw_toxicity_pred', 'sst2').
+        dataset_dir (str): Directory where the dataset is stored.
+        transformation (Callable[[Any], Any], optional): Transformation function to apply to each sample.
+        n_train (Optional[int], optional): Number of training samples.
+        n_test (Optional[int], optional): Number of test samples.
+
+    Returns:
+        Tuple[Generator[Tuple[Any, Any], None, None], Generator[Tuple[Any, Any], None, None]]:
+        Generators for training and test sets.
+    """
+    dataset_class = _get_dataset_class(dataset)
+    train_dataset, test_dataset = _create_train_test_datasets(dataset_class, dataset_dir, transformation,
+                                                              n_train, n_test)
+    return _create_generators(train_dataset, test_dataset)
+
+
+def _get_dataset_class(dataset: str) -> Type:
+    """
+    Get the dataset class based on the dataset name.
+
+    Args:
+        dataset (str): The name of the dataset.
+
+    Returns:
+        Type: The dataset class corresponding to the dataset name.
+
+    Raises:
+        ValueError: If the dataset name is unknown.
+    """
+    dataset_classes = {
+        'civil_comments': CivilCommentsDataset,
+        'jigsaw_toxicity_pred': JigsawToxicityDataset,
+        'sst2': SST2Dataset,
+    }
+    if dataset not in dataset_classes:
+        raise ValueError(f"Unknown dataset: {dataset}")
+    return dataset_classes[dataset]
+
+
+def _create_train_test_datasets(dataset_class: Type, dataset_dir: str, transformation: Optional[Callable],
+                                n_train: Optional[int], n_test: Optional[int]) \
+        -> Tuple[torch.utils.data.Dataset, torch.utils.data.Dataset]:
+    """
+    Create training and test datasets.
+
+    Args:
+        dataset_class (Type): The class of the dataset.
+        dataset_dir (str): Directory where the dataset is stored.
+        transformation (Optional[Callable]): Transformation function to apply to each sample.
+        n_train (Optional[int]): Number of training samples.
+        n_test (Optional[int]): Number of test samples.
+
+    Returns:
+        Tuple[torch.utils.data.Dataset, torch.utils.data.Dataset]: Training and test datasets.
+    """
+    train_dataset = dataset_class(dataset_dir=dataset_dir, split='train', n_samples=n_train,
+                                  transformation=transformation)
+    try:
+        test_dataset = dataset_class(dataset_dir=dataset_dir, split='test', n_samples=n_test,
+                                     transformation=transformation)
+    except KeyError:
+        test_size_ratio = _get_test_size_ratio(n_test, len(train_dataset))
+        split = train_dataset.hf_dataset.train_test_split(test_size=test_size_ratio)
+        train_dataset.hf_dataset = split['train']
+        test_dataset = dataset_class(hf_dataset=split['test'], transformation=transformation)
+    return train_dataset, test_dataset
+
+
+def _get_test_size_ratio(n_test: Optional[int], train_len: int) -> float:
+    """
+    Calculate the test size ratio.
+
+    Args:
+        n_test (Optional[int]): Number of test samples.
+        train_len (int): Length of the training dataset.
+
+    Returns:
+        float: The ratio of test samples to training samples.
+    """
+    return n_test / train_len if n_test is not None and isinstance(n_test, int) else 0.2
+
+
+def _create_generators(train_dataset: torch.utils.data.Dataset, test_dataset: torch.utils.data.Dataset) \
+        -> Tuple[Generator[Tuple[Any, Any], None, None], Generator[Tuple[Any, Any], None, None]]:
+    """
+    Create generators for training and test datasets.
+
+    Args:
+        train_dataset (torch.utils.data.Dataset): The training dataset.
+        test_dataset (torch.utils.data.Dataset): The test dataset.
+
+    Returns:
+        Tuple[Generator[Tuple[Any, Any], None, None], Generator[Tuple[Any, Any], None, None]]:
+        Generators for training and test datasets.
+    """
+    train_generator = (train_dataset[i] for i in range(len(train_dataset)))
+    test_generator = (test_dataset[i] for i in range(len(test_dataset)))
+    return train_generator, test_generator


### PR DESCRIPTION
This pull request includes several updates to the `replibert` project, focusing on improving dataset handling, configuration, and preprocessing for training and fine-tuning. The key changes include the introduction of new dataset classes, updates to configuration files, and enhancements to the preprocessing pipeline.

### Dataset Handling Enhancements:
* Introduced `FineTuningDataset` and its subclasses (`CivilCommentsDataset`, `JigsawToxicityDataset`, `SST2Dataset`) to handle specific datasets for fine-tuning (`replibert/replibert/data/finetuning/datasets.py`).
* Added `TrainingDataset` class to handle datasets for training with masked language modeling (MLM) (`replibert/replibert/data/training/dataset.py`).

### Configuration Updates:
* Updated `app.yaml` to include detailed dataset configurations for training and fine-tuning (`replibert/replibert/configuration/app.yaml`).
