### PR TITLE
Add fine-tuning results and update config

### DIFF
--- a/replibert/experiments/bert/batch_size.md
+++ b/replibert/experiments/bert/batch_size.md
@@ -1,0 +1,217 @@
+# Batch size experiments
+
+Other hyperparameters are fixed as follows:
+
+- `learning_rate=1e-4`
+- `prepocessing=False`
+- `pos_proportion=0.1`
+- `sequence_len=128`
+- `weight_decay=0.0`
+- `num_epochs=1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(batch_size=64) took 8 min 24 sec
+
+#### Training Dataset
+
+- **Loss:** 0.2393
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.77
+        - Recall: 0.81
+        - F1-Score: 0.79
+        - Support: 106,442
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.89, F1-Score: 0.88
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9802
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2303
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.62
+        - Recall: 0.78
+        - F1-Score: 0.69
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.87, F1-Score: 0.83
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9732
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2337
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.62
+        - Recall: 0.78
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.88, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9733
+
+## Config(batch_size=256) took 7 min
+
+#### Training Dataset
+
+- **Loss:** 0.2421
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.77
+        - Recall: 0.80
+        - F1-Score: 0.79
+        - Support: 106,442
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.89, F1-Score: 0.88
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9795
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2291
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.63
+        - Recall: 0.78
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.88, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9746
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2323
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.64
+        - Recall: 0.79
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.88, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9748
+
+## Config(batch_size=1024) took 7 min
+
+#### Training Dataset
+
+- **Loss:** 0.2479
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.97
+        - Recall: 0.98
+        - F1-Score: 0.97
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.79
+        - Recall: 0.75
+        - F1-Score: 0.77
+        - Support: 106,442
+    - Overall:
+        - Accuracy: 0.95
+        - Macro Avg - Precision: 0.88, Recall: 0.86, F1-Score: 0.87
+        - Weighted Avg - Precision: 0.95, Recall: 0.95, F1-Score: 0.95
+- **ROC-AUC Score:** 0.9751
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2284
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+      - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.65
+        - Recall: 0.75
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.86, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9726
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2317
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+      - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.67
+        - Recall: 0.75
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.86, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9731
+
+---
+
+## Conclusion
+
+Fine-tuning with larger batch sizes yields similar results but with a slight increase in speed (17% faster).
+Batch size 1024, however, is the maximum batch size that fits into the GPU memory.

--- a/replibert/experiments/bert/epochs.md
+++ b/replibert/experiments/bert/epochs.md
@@ -1,0 +1,281 @@
+# Epoch experiments
+
+Other hyperparameters are fixed as follows:
+
+- `learning_rate=1e-4`
+- `batch_size=512`
+- `preprocessing=False`
+- `sequence_len=256`
+- `weight_decay=0.0`
+- `pos_proportion=0.1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(num_epochs=1)
+
+#### Training Dataset
+
+- **Loss:** 0.2377
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.79
+        - Recall: 0.80
+        - F1-Score: 0.79
+        - Support: 106,438
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.88, Recall: 0.89, F1-Score: 0.89
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9837
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2248
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.65
+        - Recall: 0.78
+        - F1-Score: 0.71
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9792
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2275
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.66
+        - Recall: 0.78
+        - F1-Score: 0.72
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9798
+
+## Config(num_epochs=2)
+
+#### Training Dataset
+
+- **Loss:** 0.2303
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.76
+        - Recall: 0.86
+        - F1-Score: 0.81
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.92, F1-Score: 0.89
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9871
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2269
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.60
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.90, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9794
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2298
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.61
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.89, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9794
+
+## Config(num_epochs=3)
+
+#### Training Dataset
+
+- **Loss:** 0.2182
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.77
+        - Recall: 0.91
+        - F1-Score: 0.83
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.88, Recall: 0.94, F1-Score: 0.91
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9904
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2303
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.96
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.59
+        - Recall: 0.83
+        - F1-Score: 0.69
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.79, Recall: 0.90, F1-Score: 0.83
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9784
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2333
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.96
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.59
+        - Recall: 0.83
+        - F1-Score: 0.69
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.79, Recall: 0.90, F1-Score: 0.83
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9783
+
+## Config(epochs=5, weight_decay=1.0)
+
+#### Training Dataset
+
+- **Loss:** 0.2097
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.77
+        - Recall: 0.94
+        - F1-Score: 0.84
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.88, Recall: 0.95, F1-Score: 0.91
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9924
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2361
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.96
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.57
+        - Recall: 0.83
+        - F1-Score: 0.68
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.95
+        - Macro Avg - Precision: 0.78, Recall: 0.89, F1-Score: 0.83
+        - Weighted Avg - Precision: 0.96, Recall: 0.95, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9768
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2395
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.96
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.59
+        - Recall: 0.83
+        - F1-Score: 0.69
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.95
+        - Macro Avg - Precision: 0.79, Recall: 0.90, F1-Score: 0.83
+        - Weighted Avg - Precision: 0.96, Recall: 0.95, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9766
+
+## Conclusion
+
+More epochs do not lead to better model performance.
+Even with weight decay, the model performance does not improve.

--- a/replibert/experiments/bert/learning_rates.md
+++ b/replibert/experiments/bert/learning_rates.md
@@ -1,0 +1,330 @@
+# Learning rates experiments
+
+Other hyperparameters are fixed as follows:
+
+- `batch_size=512`
+- `prepocessing=False`
+- `pos_proportion=as_is`
+- `sequence_len=256`
+- `weight_decay=0.0`
+- `num_epochs=1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(lr=1e-7)
+
+#### Training Dataset
+
+- **Loss:** 0.4391
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.05
+        - Recall: 0.00
+        - F1-Score: 0.01
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.50, Recall: 0.50, F1-Score: 0.49
+        - Weighted Avg - Precision: 0.89, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.5066
+
+#### Validation Dataset
+
+- **Loss:** 0.4368
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.06
+        - Recall: 0.00
+        - F1-Score: 0.01
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.50, Recall: 0.50, F1-Score: 0.49
+        - Weighted Avg - Precision: 0.89, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.5066
+
+#### Testing Dataset
+
+- **Loss:** 0.4389
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.04
+        - Recall: 0.00
+        - F1-Score: 0.01
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.49, Recall: 0.50, F1-Score: 0.49
+        - Weighted Avg - Precision: 0.89, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.5104
+
+## Config(lr=1e-6)
+
+#### Training Dataset
+
+- **Loss:** 0.2312
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.69
+        - Recall: 0.70
+        - F1-Score: 0.70
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.84, Recall: 0.84, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9737
+
+#### Validation Dataset
+
+- **Loss:** 0.2276
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.69
+        - Recall: 0.71
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.84, Recall: 0.84, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9747
+
+#### Testing Dataset
+
+- **Loss:** 0.2308
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.70
+        - Recall: 0.70
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.84, Recall: 0.84, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9746
+
+## Config(lr=1e-5)
+
+#### Training Dataset
+
+- **Loss:** 0.2243
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.67
+        - Recall: 0.79
+        - F1-Score: 0.73
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.83, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9821
+
+#### Validation Dataset
+
+- **Loss:** 0.2237
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.66
+        - Recall: 0.78
+        - F1-Score: 0.71
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9803
+
+#### Testing Dataset
+
+- **Loss:** 0.2262
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.67
+        - Recall: 0.78
+        - F1-Score: 0.72
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.83, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9808
+
+## Config(lr=1e-4)
+
+#### Training Dataset
+
+- **Loss:** 0.2220
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.99
+        - F1-Score: 0.98
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.77
+        - Recall: 0.69
+        - F1-Score: 0.73
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.87, Recall: 0.84, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9822
+
+#### Validation Dataset
+
+- **Loss:** 0.2238
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.99
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.75
+        - Recall: 0.67
+        - F1-Score: 0.71
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.87, Recall: 0.83, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9786
+
+#### Testing Dataset
+
+- **Loss:** 0.2266
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.99
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.76
+        - Recall: 0.67
+        - F1-Score: 0.71
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.87, Recall: 0.83, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9791
+
+## Config(lr=1e-3)
+
+#### Training Dataset
+
+- **Loss:** 0.3359
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.00
+        - Recall: 0.00
+        - F1-Score: 0.00
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.47, Recall: 0.50, F1-Score: 0.48
+        - Weighted Avg - Precision: 0.89, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.4987
+
+#### Validation Dataset
+
+- **Loss:** 0.3316
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.00
+        - Recall: 0.00
+        - F1-Score: 0.00
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.47, Recall: 0.50, F1-Score: 0.49
+        - Weighted Avg - Precision: 0.89, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.4981
+
+#### Testing Dataset
+
+- **Loss:** 0.3353
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.00
+        - Recall: 0.00
+        - F1-Score: 0.00
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.47, Recall: 0.50, F1-Score: 0.48
+        - Weighted Avg - Precision: 0.88, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.4970
+
+---
+
+## Conclusion
+
+We tried $lr\_list=[1^{-7}, 1^{-6}, 1^{-5}, 1^{-4},1^{-3}]$.
+Except the first and last, the rest looks promising.
+We can start with the highest learning rate and then gradually decrease for multi-epoch training.

--- a/replibert/experiments/bert/pos_proportion.md
+++ b/replibert/experiments/bert/pos_proportion.md
@@ -1,0 +1,213 @@
+# Balancing experiments
+
+Other hyperparameters are fixed as follows:
+
+- `learning_rate=1e-4`
+- `batch_size=512`
+- `preprocessing=False`
+- `sequence_len=256`
+- `weight_decay=0.0`
+- `num_epochs=1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(pos_proportion=as_is) (~0.06) took 40 min
+
+#### Training Dataset
+
+- **Loss:** 0.2229
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.69
+        - Recall: 0.78
+        - F1-Score: 0.73
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.84, Recall: 0.88, F1-Score: 0.86
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9828
+
+#### Validation Dataset
+
+- **Loss:** 0.2234
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.67
+        - Recall: 0.77
+        - F1-Score: 0.72
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.83, Recall: 0.87, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9803
+
+#### Testing Dataset
+
+- **Loss:** 0.2259
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.69
+        - Recall: 0.77
+        - F1-Score: 0.73
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.84, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9810
+
+## Config(pos_proportion=0.1) took 25 min
+
+#### Training Dataset
+
+- **Loss:** 0.2377
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.79
+        - Recall: 0.80
+        - F1-Score: 0.79
+        - Support: 106,438
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.88, Recall: 0.89, F1-Score: 0.89
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9837
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2248
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.65
+        - Recall: 0.78
+        - F1-Score: 0.71
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9792
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2275
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.66
+        - Recall: 0.78
+        - F1-Score: 0.72
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.82, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9798
+
+## Config(pos_proportion=0.25)
+
+#### Training Dataset
+
+- **Loss:** 0.3120
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.97
+        - Recall: 0.94
+        - F1-Score: 0.96
+        - Support: 319,314
+    - Class 1:
+        - Precision: 0.83
+        - Recall: 0.93
+        - F1-Score: 0.88
+        - Support: 106,438
+    - Overall:
+        - Accuracy: 0.93
+        - Macro Avg - Precision: 0.90, Recall: 0.93, F1-Score: 0.92
+        - Weighted Avg - Precision: 0.94, Recall: 0.93, F1-Score: 0.94
+- **ROC-AUC Score:** 0.9822
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2413
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.93
+        - F1-Score: 0.96
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.45
+        - Recall: 0.91
+        - F1-Score: 0.61
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.93
+        - Macro Avg - Precision: 0.72, Recall: 0.92, F1-Score: 0.78
+        - Weighted Avg - Precision: 0.96, Recall: 0.93, F1-Score: 0.94
+- **ROC-AUC Score:** 0.9781
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2440
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.93
+        - F1-Score: 0.96
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.47
+        - Recall: 0.91
+        - F1-Score: 0.62
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.93
+        - Macro Avg - Precision: 0.73, Recall: 0.92, F1-Score: 0.79
+        - Weighted Avg - Precision: 0.96, Recall: 0.93, F1-Score: 0.94
+- **ROC-AUC Score:** 0.9784
+
+## Conclusion
+
+Increasing the positive proportion has a negative impact on the model's performance.
+However, for `pos_proportion=0.1` the difference is negligible, but we achieve a speedup of 38% (due to fewer data to
+process).
+Therefore, we will use `pos_proportion=0.1` for the rest of the experiments.

--- a/replibert/experiments/bert/preprocessing.md
+++ b/replibert/experiments/bert/preprocessing.md
@@ -1,0 +1,145 @@
+# Preprocessing experiments
+
+Other hyperparameters are fixed as follows:
+
+- `learning_rate=1e-4`
+- `batch_size=512`
+- `pos_proportion=as_is`
+- `sequence_len=256`
+- `weight_decay=0.0`
+- `num_epochs=1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(preprocessing=False)
+
+#### Training Dataset
+
+- **Loss:** 0.2229
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 1,698,440
+    - Class 1:
+        - Precision: 0.69
+        - Recall: 0.78
+        - F1-Score: 0.73
+        - Support: 106,440
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.84, Recall: 0.88, F1-Score: 0.86
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9828
+
+#### Validation Dataset
+
+- **Loss:** 0.2234
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.67
+        - Recall: 0.77
+        - F1-Score: 0.72
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.83, Recall: 0.87, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9803
+
+#### Testing Dataset
+
+- **Loss:** 0.2259
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.69
+        - Recall: 0.77
+        - F1-Score: 0.73
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.84, Recall: 0.88, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9810
+
+## Config(preprocessing=True)
+
+#### Training Dataset
+
+- **Loss:** 0.2264
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.99
+        - F1-Score: 0.98
+        - Support: 1,698,438
+    - Class 1:
+        - Precision: 0.74
+        - Recall: 0.67
+        - F1-Score: 0.70
+        - Support: 106,438
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.86, Recall: 0.83, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9777
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2275
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,671
+    - Class 1:
+        - Precision: 0.72
+        - Recall: 0.66
+        - F1-Score: 0.69
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.85, Recall: 0.82, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.96, Recall: 0.97, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9738
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2304
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,532
+    - Class 1:
+        - Precision: 0.73
+        - Recall: 0.66
+        - F1-Score: 0.69
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.85, Recall: 0.82, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.96, Recall: 0.97, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9748
+
+## Conclusion
+
+Preprocessing has no positive impact on model performance.
+It even shows a slight negative impact on the model's class 1 F1-score (0.72 -> 0.69).

--- a/replibert/experiments/bert/regularization.md
+++ b/replibert/experiments/bert/regularization.md
@@ -1,0 +1,347 @@
+# Regularization experiments
+
+Other hyperparameters are fixed as follows:
+
+- `learning_rate=1e-4`
+- `batch_size=512`
+- `preprocessing=False`
+- `sequence_len=256`
+- `epochs=2`
+- `pos_proportion=0.1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(weight_decay=0.0)
+
+#### Training Dataset
+
+- **Loss:** 0.2303
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.76
+        - Recall: 0.86
+        - F1-Score: 0.81
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.92, F1-Score: 0.89
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9871
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2269
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.60
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.90, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9794
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2298
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.61
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.89, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9794
+
+## Config(weight_decay=0.1)
+
+#### Training Dataset
+
+- **Loss:** 0.2351
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.76
+        - Recall: 0.85
+        - F1-Score: 0.80
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.91, F1-Score: 0.89
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9853
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2268
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.60
+        - Recall: 0.83
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.90, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9797
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2297
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.61
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.90, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9796
+
+## Config(weight_decay=1.0)
+
+#### Training Dataset
+
+- **Loss:** 0.2335
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.76
+        - Recall: 0.86
+        - F1-Score: 0.81
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.91, F1-Score: 0.89
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9864
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2265
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.60
+        - Recall: 0.83
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.90, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9799
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2295
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.61
+        - Recall: 0.83
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.90, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9799
+
+## Config(weight_decay=10.0)
+
+#### Training Dataset
+
+- **Loss:** 0.2458
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.97
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.77
+        - Recall: 0.78
+        - F1-Score: 0.77
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.95
+        - Macro Avg - Precision: 0.87, Recall: 0.88, F1-Score: 0.87
+        - Weighted Avg - Precision: 0.95, Recall: 0.95, F1-Score: 0.95
+- **ROC-AUC Score:** 0.9795
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2298
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.63
+        - Recall: 0.78
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.88, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9764
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2326
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.64
+        - Recall: 0.77
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.87, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9768
+
+## Config(weight_decay=100.0)
+
+#### Training Dataset
+
+- **Loss:** 0.6076
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.90
+        - Recall: 1.00
+        - F1-Score: 0.95
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.00
+        - Recall: 0.00
+        - F1-Score: 0.00
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.90
+        - Macro Avg - Precision: 0.45, Recall: 0.50, F1-Score: 0.47
+        - Weighted Avg - Precision: 0.81, Recall: 0.90, F1-Score: 0.85
+- **ROC-AUC Score:** 0.5153
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.6005
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.00
+        - Recall: 0.00
+        - F1-Score: 0.00
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.47, Recall: 0.50, F1-Score: 0.49
+        - Weighted Avg - Precision: 0.89, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.5174
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.6009
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.94
+        - Recall: 1.00
+        - F1-Score: 0.97
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.00
+        - Recall: 0.00
+        - F1-Score: 0.00
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.94
+        - Macro Avg - Precision: 0.47, Recall: 0.50, F1-Score: 0.48
+        - Weighted Avg - Precision: 0.88, Recall: 0.94, F1-Score: 0.91
+- **ROC-AUC Score:** 0.5153
+
+## Conclusion
+
+Weight decay has no significant effect on the model performance.
+Only unreasonably high values of weight decay lead to a loss of learning capacity.

--- a/replibert/experiments/bert/sequence_len.md
+++ b/replibert/experiments/bert/sequence_len.md
@@ -1,0 +1,281 @@
+# Sequence length experiments
+
+Other hyperparameters are fixed as follows:
+
+- `learning_rate=1e-4`
+- `batch_size=512`
+- `preprocessing=False`
+- `weight_decay=0.0`
+- `epochs=1`
+- `pos_proportion=0.1`
+- `optimizer=AdamW`
+- `loss=BCEWithLogitsLoss`
+
+## Config(sequence_len=64) took 4 min
+
+#### Training Dataset
+
+- **Loss:** 0.2563
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.97
+        - Recall: 0.98
+        - F1-Score: 0.97
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.78
+        - Recall: 0.72
+        - F1-Score: 0.75
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.95
+        - Macro Avg - Precision: 0.87, Recall: 0.85, F1-Score: 0.86
+        - Weighted Avg - Precision: 0.95, Recall: 0.95, F1-Score: 0.95
+- **ROC-AUC Score:** 0.9628
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2391
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.64
+        - Recall: 0.70
+        - F1-Score: 0.66
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.84, F1-Score: 0.82
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9566
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2416
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.64
+        - Recall: 0.71
+        - F1-Score: 0.68
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.84, F1-Score: 0.83
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9572
+
+## Config(sequence_len=128) took 8 min
+
+#### Training Dataset
+
+- **Loss:** 0.2457
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.97
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.76
+        - Recall: 0.81
+        - F1-Score: 0.78
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.95
+        - Macro Avg - Precision: 0.87, Recall: 0.89, F1-Score: 0.88
+        - Weighted Avg - Precision: 0.96, Recall: 0.95, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9783
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2308
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.61
+        - Recall: 0.79
+        - F1-Score: 0.69
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.88, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9745
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2337
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.62
+        - Recall: 0.80
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.81, Recall: 0.88, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9747
+
+## Config(sequence_len=256) took 15 min
+
+#### Training Dataset
+
+- **Loss:** 0.2425
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.75
+        - Recall: 0.83
+        - F1-Score: 0.79
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.87, Recall: 0.90, F1-Score: 0.88
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9831
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2284
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.61
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.89, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9797
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2309
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.99
+        - Recall: 0.97
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.62
+        - Recall: 0.82
+        - F1-Score: 0.70
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.80, Recall: 0.89, F1-Score: 0.84
+        - Weighted Avg - Precision: 0.97, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9800
+
+## Config(sequence_len=512, batch_size=128) took 30 min
+
+#### Training Dataset
+
+- **Loss:** 0.2342
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.97
+        - Recall: 0.99
+        - F1-Score: 0.98
+        - Support: 957,942
+    - Class 1:
+        - Precision: 0.85
+        - Recall: 0.73
+        - F1-Score: 0.78
+        - Support: 106,443
+    - Overall:
+        - Accuracy: 0.96
+        - Macro Avg - Precision: 0.91, Recall: 0.86, F1-Score: 0.88
+        - Weighted Avg - Precision: 0.96, Recall: 0.96, F1-Score: 0.96
+- **ROC-AUC Score:** 0.9846
+
+---
+
+#### Validation Dataset
+
+- **Loss:** 0.2237
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,672
+    - Class 1:
+        - Precision: 0.71
+        - Recall: 0.71
+        - F1-Score: 0.71
+        - Support: 5,649
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.85, Recall: 0.85, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9788
+
+---
+
+#### Testing Dataset
+
+- **Loss:** 0.2264
+- **Classification Report:**
+    - Class 0:
+        - Precision: 0.98
+        - Recall: 0.98
+        - F1-Score: 0.98
+        - Support: 91,533
+    - Class 1:
+        - Precision: 0.72
+        - Recall: 0.72
+        - F1-Score: 0.72
+        - Support: 5,788
+    - Overall:
+        - Accuracy: 0.97
+        - Macro Avg - Precision: 0.85, Recall: 0.85, F1-Score: 0.85
+        - Weighted Avg - Precision: 0.97, Recall: 0.97, F1-Score: 0.97
+- **ROC-AUC Score:** 0.9795
+
+## Conclusion
+
+BERT's default sequence length is 512.
+We can reduce to 128 without significant performance loss, achieving a speedup of 4x and enabling larger batch sizes.

--- a/replibert/replibert/configuration/app.yaml
+++ b/replibert/replibert/configuration/app.yaml
@@ -28,13 +28,13 @@ model:
   hidden_size: 768
   num_layers: 12
   num_heads: 12
-  max_position_embeddings: 256
+  max_position_embeddings: 128
   vocab_size: 30522
 
 finetuning:
   dataset_fraction: 1.0
   pos_proportion: null
-  batch_size: 512
+  batch_size: 1024
   learning_rate: 1e-4
   weight_decay: 0.0
   num_epochs: 1

--- a/replibert/replibert/data/finetuning/transform.py
+++ b/replibert/replibert/data/finetuning/transform.py
@@ -11,7 +11,7 @@ from sklearn.utils import resample
 from torch.utils.data import Subset
 from transformers import BertTokenizer
 
-from configuration.config import get_logger
+from configuration.config import get_logger, settings
 from data.finetuning.datasets import FineTuningDataset
 from utils import get_available_cpus
 
@@ -57,13 +57,14 @@ def tf_idf_vectorize(train_dataset: FineTuningDataset, val_dataset: FineTuningDa
                                       num_proc=get_available_cpus(), desc="Vectorizing test dataset")
 
 
-def bert_tokenize(dataset: Dataset, text_field: str) -> Dataset:
+def bert_tokenize(dataset: Dataset, text_field: str, config: dict = settings["model"]) -> Dataset:
     """
     Tokenizes the text data in the given dataset using the BERT tokenizer.
 
     Args:
         dataset (Dataset): The HuggingFace dataset to tokenize.
         text_field (str): The field containing the text data.
+        config (dict): Configuration settings.
 
     Returns:
         Dataset: The tokenized dataset.
@@ -74,7 +75,7 @@ def bert_tokenize(dataset: Dataset, text_field: str) -> Dataset:
         texts = batch[text_field]
         tokenized = tokenizer(
             texts,
-            max_length=256,
+            max_length=config["max_position_embeddings"],
             padding="max_length",
             truncation=True,
             return_tensors="pt"

--- a/replibert/replibert/main.py
+++ b/replibert/replibert/main.py
@@ -185,15 +185,15 @@ def tokenize(dataset_dir: str, text_field: str, preprocess: bool, destination: s
               help="Name of the dataset to use. Options are: 'civil_comments', 'jigsaw_toxicity_pred', 'sst2'.")
 @click.option("--dataset_dir", type=click.Path(exists=True), required=True,
               help="Directory containing the tokenized dataset to process.")
-@click.option("--weights_dir", type=click.Path(), help="Directory to save the model weights.")
-def finetune(dataset_name: str, dataset_dir: str, weights_dir: str = None):
+@click.option("--weight_dir", type=click.Path(), help="Directory to save the model weights.")
+def finetune(dataset_name: str, dataset_dir: str, weight_dir: str = None):
     """
     Fine-tune a BERT model on the specified dataset.
 
     Parameters:
     dataset_name (str): Name of the dataset to use.
     dataset_dir (str): Directory containing the dataset to process.
-    weights_dir (str): Directory to save the model weights.
+    weight_dir (str): Directory to save the model weights.
     """
     from finetuning.classification import finetune as finetune_model
     from data.utils import load_data
@@ -207,7 +207,7 @@ def finetune(dataset_name: str, dataset_dir: str, weights_dir: str = None):
     val_dataset.input_field = ['input_ids', 'attention_mask']
     test_dataset.input_field = ['input_ids', 'attention_mask']
 
-    finetune_model(train_dataset, val_dataset, test_dataset, weights_dir)
+    finetune_model(train_dataset, val_dataset, test_dataset, weight_dir)
 
 
 @cli.command()


### PR DESCRIPTION
This pull request includes several changes to the `replibert/experiments/bert` directory to document various experiments conducted with different hyperparameters. The changes are grouped by the type of hyperparameter being experimented with: batch size, number of epochs, learning rates, and positive class proportion.

### Batch Size Experiments:
* Added results for batch sizes of 64, 256, and 1024, documenting the training, validation, and testing dataset performance metrics.

### Epoch Experiments:
* Added results for 1, 2, 3, and 5 epochs, including performance metrics for training, validation, and testing datasets.

### Learning Rate Experiments:
* Added results for learning rates of 1e-7, 1e-6, 1e-5, 1e-4, and 1e-3, documenting the performance metrics for training, validation, and testing datasets.

### Positive Proportion Experiments:
* Added results for positive class proportions of `as_is` (~0.06), 0.1, and 0.25, including performance metrics for training, validation, and testing datasets.