### PR TITLE
Add focal loss

### DIFF
--- a/replibert/replibert/configuration/app.yaml
+++ b/replibert/replibert/configuration/app.yaml
@@ -33,7 +33,7 @@ model:
 
 finetuning:
   dataset_fraction: 1.0
-  pos_proportion: 0.1
+  pos_proportion: null
   batch_size: 1024
   learning_rate: 1e-4
   weight_decay: 0.0

--- a/replibert/replibert/finetuning/classification.py
+++ b/replibert/replibert/finetuning/classification.py
@@ -14,6 +14,7 @@ from configuration.config import settings, get_logger
 from data.finetuning.datasets import FineTuningDataset
 from data.finetuning.transform import balance_dataset
 from finetuning.evaluate import evaluate_on_all_datasets
+from finetuning.loss import FocalLoss
 from model.initialize import initialize_with_weights
 from model.model import Bert, BertToxic
 from utils import get_available_cpus, is_main_process, _initialize_distributed
@@ -85,7 +86,7 @@ def _finetune_model(model: nn.Module, train_dataset: FineTuningDataset, val_data
     train_loader = _get_train_data_loader(train_dataset, rank, world_size, config)
     optimizer = optim.AdamW(model.parameters(), lr=float(config["learning_rate"]),
                             weight_decay=float(config["weight_decay"]))
-    criterion = nn.BCEWithLogitsLoss().to(config["device"])
+    criterion = FocalLoss().to(config["device"])
     scaler = GradScaler()
     for epoch in range(config["num_epochs"]):
         train_loader.sampler.set_epoch(epoch)

--- a/replibert/replibert/finetuning/loss.py
+++ b/replibert/replibert/finetuning/loss.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn.functional as F
+
+
+class FocalLoss(torch.nn.Module):
+    def __init__(self, alpha: float = 0.25, gamma: float = 2.0) -> None:
+        """
+        Initializes the FocalLoss module.
+
+        Args:
+            alpha (float): Weighting factor for the class. Default is 0.25.
+            gamma (float): Focusing parameter. Default is 2.0.
+        """
+        super(FocalLoss, self).__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+
+    def forward(self, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """
+        Computes the focal loss between `inputs` and `targets`.
+
+        Args:
+            inputs (torch.Tensor): Predicted logits.
+            targets (torch.Tensor): Ground truth labels.
+
+        Returns:
+            torch.Tensor: Computed focal loss.
+        """
+        bce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction='none')
+        pt = torch.exp(-bce_loss)
+        f_loss = self.alpha * (1 - pt) ** self.gamma * bce_loss
+        return f_loss.mean()


### PR DESCRIPTION
This pull request introduces changes to the `replibert` project, focusing on updating the loss function used during fine-tuning and modifying the configuration settings. The most important changes include the addition of a new `FocalLoss` class, updating the fine-tuning process to use this new loss function, and adjusting the configuration file.

### Loss Function Update:
* [`replibert/replibert/finetuning/classification.py`](diffhunk://#diff-07015452b56dc12b4eeac7bdf2a46bbf3862805b1d1644b545f10ba80e3eb5adL88-R89): Replaced the loss function from `nn.BCEWithLogitsLoss` to the newly introduced `FocalLoss` to improve model performance on imbalanced datasets.
* [`replibert/replibert/finetuning/loss.py`](diffhunk://#diff-66b99ae71ae7f8935f6d7f1a044976a8c83cc0f4c28e645aede7745ea839d66fR1-R32): Added a new `FocalLoss` class to handle imbalanced datasets by focusing more on hard-to-classify examples.

### Configuration Changes:
* [`replibert/replibert/configuration/app.yaml`](diffhunk://#diff-e7d88e68e5036a8889737d6bba5731d10089d34d08d7bc5fb8b8054f9beda1c4L36-R36): Set the `pos_proportion` parameter to `null` to allow for dynamic adjustment during fine-tuning.